### PR TITLE
Revamp of the classify API endpoint, utilizing GCP bucket for model downloading/uploading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ coverage==7.6.10
 pre-commit==4.1.0
 onnxruntime==1.20.1
 onnx==1.17.0
+google-cloud-storage==2.19.0
+python-multipart==0.0.20

--- a/src/face_classification/api.py
+++ b/src/face_classification/api.py
@@ -1,22 +1,41 @@
+import os
+import shutil
+from contextlib import asynccontextmanager
+from tempfile import NamedTemporaryFile
+
 import numpy as np
 import onnxruntime
 import torchvision.transforms as transforms
-from fastapi import FastAPI
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from google.cloud import storage
+from PIL import Image
 
 from face_classification.evaluate import evaluate
 from face_classification.train import train
 
-app = FastAPI()
-from PIL import Image
 
+def download_from_gcs(bucket_name, source_blob_name, destination_file_name):
+    """Downloads a file from GCS."""
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
 
-@app.get("/predict_single_image")
-def predict_single_image(image_path: str):
-    """Predict using ONNX model."""
+    blob.download_to_filename(destination_file_name)
+    print(f"File {source_blob_name} downloaded to {destination_file_name}.")
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Context manager to start and stop the lifespan events of the FastAPI application."""
+    global model, transform, imagenet_classes
     # Load the ONNX model
-    model = onnxruntime.InferenceSession("models/model_final.onnx")
+    model_path = "models/model_final.onnx"
+    if not os.path.exists(model_path):
+        bucket_name = "face-classification-models"
+        source_blob_name = "models/model_final.onnx"
+        download_from_gcs(bucket_name, source_blob_name, model_path)
 
-    # Define the test dataset and dataloader
+    model = onnxruntime.InferenceSession(model_path)
+
     transform = transforms.Compose(
         [
             transforms.Resize((256, 256)),
@@ -24,6 +43,23 @@ def predict_single_image(image_path: str):
         ]
     )
 
+    yield
+
+    # Clean up
+    del model
+    del transform
+
+
+app = FastAPI(lifespan=lifespan)
+
+@app.get("/")
+async def root():
+    """Root endpoint."""
+    return {"message": "Backend here!"}
+
+@app.get("/predict_single_image")
+def predict_single_image(image_path: str):
+    """Predict using ONNX model."""
     # Open and preprocess the image
     image = Image.open(image_path).convert("RGB")  # Ensure 3 channels
     image = transform(image)
@@ -34,10 +70,31 @@ def predict_single_image(image_path: str):
 
     # Perform inference
     output = model.run(None, {input_name: image})
-    output_class = int(np.argmax(output))
+    probabilities = np.exp(output) / np.sum(np.exp(output))
+    prediction = int(np.argmax(output))
+    print(f"Predicted class: Person {prediction}")
 
-    return {"output class": output_class}
+    return probabilities, prediction
 
+# FastAPI endpoint for image classification
+@app.post("/classify/")
+async def classify_image(file: UploadFile = File(...)):
+    """Classify image endpoint."""
+    try:
+        # Save the uploaded file to a temporary location
+        with NamedTemporaryFile(delete=False, suffix=".jpg") as temp_file:
+            shutil.copyfileobj(file.file, temp_file)
+            temp_file_path = temp_file.name
+
+        # Use the saved file for prediction
+        probabilities, prediction = predict_single_image(temp_file_path)
+
+        # Remove the temporary file after use
+        os.remove(temp_file_path)
+
+        return {"filename": file.filename, "prediction": prediction, "probabilities": probabilities.tolist()}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/train_model")
 def train_model():

--- a/src/face_classification/api.py
+++ b/src/face_classification/api.py
@@ -26,7 +26,7 @@ def download_from_gcs(bucket_name, source_blob_name, destination_file_name):
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Context manager to start and stop the lifespan events of the FastAPI application."""
-    global model, transform, imagenet_classes
+    global model, transform
     # Load the ONNX model
     model_path = "models/model_final.onnx"
     if not os.path.exists(model_path):
@@ -94,6 +94,7 @@ async def classify_image(file: UploadFile = File(...)):
 
         return {"filename": file.filename, "prediction": prediction, "probabilities": probabilities.tolist()}
     except Exception as e:
+        print(e)
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/train_model")

--- a/src/face_classification/client.py
+++ b/src/face_classification/client.py
@@ -9,10 +9,11 @@ class FaceClassificationClient:
     def __init__(self, base_url="http://localhost:8000"):
         self.base_url = base_url
 
-    def predict_single_image(self, image_path):
-        url = f"{self.base_url}/predict_single_image"
-        params = {"image_path": image_path}
-        response = requests.get(url, params=params)
+    def classify_image(self, image_path):
+        url = f"{self.base_url}/classify/"
+        with open(image_path, "rb") as image_file:
+            files = {"file": (image_path, image_file, "image/jpeg")}
+            response = requests.post(url, files=files)
         return response.json()
 
     def train_model(self):
@@ -37,18 +38,18 @@ def main():
     client = FaceClassificationClient(base_url=base_url)
 
     while True:
-        command = input("Enter command (train, evaluate, predict, exit): ").strip().lower()
+        command = input("Enter command (train, evaluate, classify, exit): ").strip().lower()
         if command == "train":
             print(client.train_model())
         elif command == "evaluate":
             print(client.evaluate_model())
-        elif command == "predict":
+        elif command == "classify":
             image_path = input("Enter image path: ").strip()
-            print(client.predict_single_image(image_path))
+            print(client.classify_image(image_path))
         elif command == "exit":
             break
         else:
-            print("Unknown command. Please enter 'train', 'evaluate', 'predict', or 'exit'.")
+            print("Unknown command. Please enter 'train', 'evaluate', 'classify', or 'exit'.")
 
 
 if __name__ == "__main__":

--- a/src/face_classification/metric_tracker.py
+++ b/src/face_classification/metric_tracker.py
@@ -1,7 +1,8 @@
 import pytorch_lightning as pl
 import torch
-import wandb
 from pytorch_lightning.callbacks import Callback
+
+import wandb
 
 wandb.login()
 wandb_logger = pl.loggers.WandbLogger(project="face_classification")

--- a/src/face_classification/train.py
+++ b/src/face_classification/train.py
@@ -4,13 +4,14 @@ import os
 import hydra
 import torch
 import typer
-import wandb
+from google.cloud import storage
 from omegaconf import OmegaConf
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
 from torch.profiler import ProfilerActivity, profile, tensorboard_trace_handler
 
+import wandb
 from face_classification.data import FaceDataset
 from face_classification.metric_tracker import MetricTracker
 from face_classification.model import PretrainedResNet34
@@ -20,6 +21,32 @@ import wandb
 
 wandb.login()
 
+def upload_to_gcs(bucket_name, source_file_name, destination_blob_name):
+    """Uploads a file to the GCS bucket."""
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.upload_from_filename(source_file_name)
+    print(f"File {source_file_name} uploaded to {destination_blob_name}.")
+
+def save_model_to_onnx(model, checkpoint_path, output_path):
+    """Loads the best PyTorch checkpoint and converts it to ONNX."""
+    checkpoint = torch.load(checkpoint_path)
+    model.load_state_dict(checkpoint["state_dict"])  # Load the checkpoint weights
+    model.eval()  # Ensure the model is in evaluation mode
+
+    dummy_input = torch.randn(1, 3, 256, 256, device="cpu")  # Adjust input dimensions as needed
+    model.to_onnx(output_path, dummy_input, export_params=True)
+
+    print(f"Model successfully exported to {output_path}")
+
+def save_pytorch_model_weights(model, checkpoint_path, output_path):
+    """Saves the PyTorch model weights."""
+    checkpoint = torch.load(checkpoint_path)
+    model.load_state_dict(checkpoint["state_dict"])  # Load the checkpoint weights
+    torch.save(model.state_dict(), output_path)
+    print(f"PyTorch model weights saved to {output_path}")
 
 @app.command()
 def train(config_name: str = "default_config") -> None:
@@ -108,6 +135,19 @@ def run_training(cfg, hparams) -> None:
 
     # Log the model to W&B registry
     if best_model_path:  # Ensure a model checkpoint exists
+        # Save the ONNX model
+        onnx_model_path = "models/model_final.onnx"
+        save_model_to_onnx(model, best_model_path, onnx_model_path)
+
+        # Save the PyTorch model weights
+        pytorch_weights_path = "models/model_weights.pth"
+        save_pytorch_model_weights(model, best_model_path, pytorch_weights_path)
+
+        # Upload models to GCP
+        bucket_name = "face-classification-models"
+        upload_to_gcs(bucket_name, onnx_model_path, "models/model_final.onnx")
+        upload_to_gcs(bucket_name, pytorch_weights_path, "models/model_weights.pth")
+
         artifact = wandb.Artifact(
             name="face_classification_model",
             type="model",


### PR DESCRIPTION
I changed our predict endpoint to classify endpoint, and now it works by sending it an image (like it does in M26 example).
Added soem changes to the client.py which I used to test the deployed API in the cloud, to make sure it all works. That file will be deleted later once the frontend is in.